### PR TITLE
Adds ferry bulletin to sailings screen

### DIFF
--- a/wsdot/AppDelegate.swift
+++ b/wsdot/AppDelegate.swift
@@ -168,12 +168,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let ferriesNav = mainStoryboard.instantiateViewController(withIdentifier: "FerriesNav") as! UINavigationController
         
         let ferrySchedules = mainStoryboard.instantiateViewController(withIdentifier: "RouteSchedulesViewController") as! RouteSchedulesViewController
+        
+        let ferrySailings = mainStoryboard.instantiateViewController(withIdentifier: "RouteDeparturesViewController") as! RouteDeparturesViewController
+        
+        ferrySailings.routeId = routeId
+        
         let ferryAlerts = mainStoryboard.instantiateViewController(withIdentifier: "RouteAlertsViewController") as! RouteAlertsViewController
   
         ferryAlerts.routeId = routeId
         
         // assign vc stack to new nav controller
-        ferriesNav.setViewControllers([ferrySchedules, ferryAlerts], animated: false)
+        ferriesNav.setViewControllers([ferrySchedules, ferrySailings, ferryAlerts], animated: false)
 
         setNavController(newNavigationController: ferriesNav)
 

--- a/wsdot/Base.lproj/Ferries.storyboard
+++ b/wsdot/Base.lproj/Ferries.storyboard
@@ -30,52 +30,37 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KeP-V2-pdz" userLabel="Sub Title">
-                                                    <rect key="frame" x="23" y="79.5" width="205" height="23"/>
+                                                    <rect key="frame" x="23" y="85.5" width="205" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" red="0.66666666669999997" green="0.66666666669999997" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qnx-NK-9Y2">
-                                                    <rect key="frame" x="23" y="11" width="311" height="34.5"/>
+                                                    <rect key="frame" x="23" y="11" width="311" height="40.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WkA-uH-eZL">
-                                                    <rect key="frame" x="23" y="53.5" width="311" height="18"/>
+                                                    <rect key="frame" x="23" y="59.5" width="311" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="I4S-hS-7KT">
-                                                    <rect key="frame" x="236" y="79.5" width="99" height="27"/>
-                                                    <color key="backgroundColor" red="0.93581814236111116" green="0.41981336805555558" blue="0.088704427083333329" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="27" id="QJ6-Qb-JZd"/>
-                                                    </constraints>
-                                                    <state key="normal" title="Button">
-                                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    </state>
-                                                </button>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailingMargin" secondItem="I4S-hS-7KT" secondAttribute="trailing" constant="-1" id="4pZ-aZ-Sgl"/>
                                                 <constraint firstItem="WkA-uH-eZL" firstAttribute="leading" secondItem="KeP-V2-pdz" secondAttribute="leading" id="570-wO-Flk"/>
                                                 <constraint firstAttribute="bottomMargin" secondItem="KeP-V2-pdz" secondAttribute="bottom" constant="1.5" id="868-7N-Quf"/>
-                                                <constraint firstItem="I4S-hS-7KT" firstAttribute="leading" secondItem="KeP-V2-pdz" secondAttribute="trailing" constant="8" id="LxS-CM-FTP"/>
                                                 <constraint firstItem="WkA-uH-eZL" firstAttribute="top" secondItem="Qnx-NK-9Y2" secondAttribute="bottom" constant="8" symbolic="YES" id="Nrm-7w-led"/>
                                                 <constraint firstItem="Qnx-NK-9Y2" firstAttribute="leading" secondItem="WkA-uH-eZL" secondAttribute="leading" id="PHg-pt-uf1"/>
                                                 <constraint firstItem="Qnx-NK-9Y2" firstAttribute="trailing" secondItem="WkA-uH-eZL" secondAttribute="trailing" id="Uyh-lI-1TR"/>
                                                 <constraint firstItem="Qnx-NK-9Y2" firstAttribute="trailing" secondItem="IDX-zS-yNH" secondAttribute="trailingMargin" id="W7I-YK-w5E"/>
                                                 <constraint firstItem="KeP-V2-pdz" firstAttribute="top" secondItem="WkA-uH-eZL" secondAttribute="bottom" constant="8" symbolic="YES" id="Ykm-bk-FCd"/>
                                                 <constraint firstItem="KeP-V2-pdz" firstAttribute="width" secondItem="IDX-zS-yNH" secondAttribute="width" multiplier="0.6" id="gwp-gN-k8p"/>
-                                                <constraint firstItem="I4S-hS-7KT" firstAttribute="top" secondItem="WkA-uH-eZL" secondAttribute="bottom" constant="8" id="ia1-TL-aGa"/>
                                                 <constraint firstItem="Qnx-NK-9Y2" firstAttribute="leading" secondItem="IDX-zS-yNH" secondAttribute="leadingMargin" constant="8" id="m3L-aK-BZ8"/>
-                                                <constraint firstAttribute="bottom" secondItem="I4S-hS-7KT" secondAttribute="bottom" constant="8" id="tLX-da-wdg"/>
                                                 <constraint firstItem="Qnx-NK-9Y2" firstAttribute="top" secondItem="IDX-zS-yNH" secondAttribute="topMargin" id="zlp-Iv-vQI"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <outlet property="button" destination="I4S-hS-7KT" id="l4z-xJ-bNg"/>
                                             <outlet property="subTitleOne" destination="WkA-uH-eZL" id="Ta0-Vk-oaJ"/>
                                             <outlet property="subTitleTwo" destination="KeP-V2-pdz" id="O2H-vZ-v9b"/>
                                             <outlet property="title" destination="Qnx-NK-9Y2" id="eYg-P7-Gq0"/>
@@ -138,7 +123,6 @@
                         <outlet property="bannerView" destination="QPe-xF-yKL" id="55x-6x-Hte"/>
                         <outlet property="tableView" destination="7iQ-pr-2le" id="lTr-Gk-HQl"/>
                         <segue destination="zsX-Zv-QLD" kind="show" identifier="RouteDeparturesViewController" id="BBr-Ay-eTJ"/>
-                        <segue destination="7rf-f5-hN4" kind="show" identifier="RouteAlertsViewController" id="Eb4-Cd-6U4"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="f2f-if-6x1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -439,11 +423,11 @@
             <objects>
                 <viewController storyboardIdentifier="RouteAlertsViewController" id="7rf-f5-hN4" customClass="RouteAlertsViewController" customModule="WSDOT" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="I5c-gP-h5w">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="193" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="VJP-3Q-OpG">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="RouteAlerts" rowHeight="193" id="6sV-50-wR4" customClass="LinkCell" customModule="WSDOT" customModuleProvider="target">
@@ -490,24 +474,33 @@
                                     <outlet property="delegate" destination="7rf-f5-hN4" id="moT-xS-vLy"/>
                                 </connections>
                             </tableView>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="SyC-ag-ddK">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                                <color key="color" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="SyC-ag-ddK" firstAttribute="top" secondItem="zWm-0R-n2P" secondAttribute="top" id="4CR-Mg-3iM"/>
                             <constraint firstItem="VJP-3Q-OpG" firstAttribute="leading" secondItem="zWm-0R-n2P" secondAttribute="leading" id="8L3-fd-lsc"/>
                             <constraint firstItem="VJP-3Q-OpG" firstAttribute="bottom" secondItem="zWm-0R-n2P" secondAttribute="bottom" id="F4Q-hg-Cvq"/>
                             <constraint firstItem="zWm-0R-n2P" firstAttribute="trailing" secondItem="VJP-3Q-OpG" secondAttribute="trailing" id="GKo-Q4-yl1"/>
                             <constraint firstItem="VJP-3Q-OpG" firstAttribute="top" secondItem="I5c-gP-h5w" secondAttribute="top" id="Ko5-gd-fJP"/>
+                            <constraint firstItem="SyC-ag-ddK" firstAttribute="trailing" secondItem="zWm-0R-n2P" secondAttribute="trailing" id="S3D-BC-rmw"/>
+                            <constraint firstItem="SyC-ag-ddK" firstAttribute="leading" secondItem="zWm-0R-n2P" secondAttribute="leading" id="hUL-bh-rWB"/>
+                            <constraint firstItem="zWm-0R-n2P" firstAttribute="bottom" secondItem="SyC-ag-ddK" secondAttribute="bottom" id="wJ4-pV-zey"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="zWm-0R-n2P"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Alerts" image="icAlertTab" id="e50-de-Ugu"/>
                     <connections>
+                        <outlet property="activityIndicator" destination="SyC-ag-ddK" id="4W6-hY-wMq"/>
                         <outlet property="tableView" destination="VJP-3Q-OpG" id="CNk-yN-kcF"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JlM-gg-ob8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3294" y="-846"/>
+            <point key="canvasLocation" x="3294" y="-1001"/>
         </scene>
         <!--Route Departures View Controller-->
         <scene sceneID="nLr-PW-gpl">
@@ -653,6 +646,7 @@
                         <outlet property="vesselWatchContainerView" destination="kSn-7K-XNe" id="5AC-IR-i7P"/>
                         <segue destination="gt2-Sv-UWX" kind="presentation" identifier="DepartureDaySelectionViewController" id="29B-j8-1x6"/>
                         <segue destination="2La-UL-XHc" kind="presentation" identifier="TerminalSelectionViewController" id="RFb-8t-MIv"/>
+                        <segue destination="7rf-f5-hN4" kind="show" identifier="RouteAlertsViewController" id="ie8-9Q-8SK"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RFS-Ka-R4z" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -904,27 +898,27 @@
                                     <outlet property="delegate" destination="Whq-2K-wR1" id="1vz-Zl-Mmy"/>
                                 </connections>
                             </tableView>
-                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="751" verticalHuggingPriority="751" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="2sB-gh-yRe">
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="751" verticalHuggingPriority="751" hidesWhenStopped="YES" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="2sB-gh-yRe">
                                 <rect key="frame" x="169" y="214.5" width="37" height="37"/>
-                                <color key="color" white="0.66666666669999997" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="color" white="0.67000000000000004" alpha="1" colorSpace="calibratedWhite"/>
                             </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="ea4-dX-pgd" firstAttribute="top" secondItem="tvM-vn-PsU" secondAttribute="bottom" identifier="departure times table top" id="3Gf-Ze-Tt8"/>
                             <constraint firstItem="ea4-dX-pgd" firstAttribute="leading" secondItem="z2y-8B-H2y" secondAttribute="leading" identifier="departure times table leading" id="6C5-hs-dh9"/>
-                            <constraint firstItem="2sB-gh-yRe" firstAttribute="centerY" secondItem="OXS-G6-73x" secondAttribute="centerY" id="K5a-a0-wg1"/>
+                            <constraint firstItem="2sB-gh-yRe" firstAttribute="centerX" secondItem="OXS-G6-73x" secondAttribute="centerX" id="NaI-MH-aWt"/>
                             <constraint firstItem="ea4-dX-pgd" firstAttribute="trailing" secondItem="z2y-8B-H2y" secondAttribute="trailing" identifier="departures table trailing" id="NsJ-nX-4cW"/>
                             <constraint firstItem="ea4-dX-pgd" firstAttribute="bottom" secondItem="z2y-8B-H2y" secondAttribute="bottom" identifier="departure times tabel bottom" id="Q7T-bJ-nUK"/>
+                            <constraint firstItem="2sB-gh-yRe" firstAttribute="centerY" secondItem="OXS-G6-73x" secondAttribute="centerY" id="c0H-DL-Byu"/>
                             <constraint firstItem="tvM-vn-PsU" firstAttribute="leading" secondItem="ea4-dX-pgd" secondAttribute="leading" identifier="departures header leading" id="ckq-lu-4LM"/>
                             <constraint firstItem="tvM-vn-PsU" firstAttribute="trailing" secondItem="ea4-dX-pgd" secondAttribute="trailing" identifier="departures header trailing" id="eFs-JR-nVz"/>
-                            <constraint firstItem="2sB-gh-yRe" firstAttribute="centerX" secondItem="OXS-G6-73x" secondAttribute="centerX" id="vEf-hY-ye1"/>
                             <constraint firstItem="tvM-vn-PsU" firstAttribute="top" secondItem="z2y-8B-H2y" secondAttribute="top" identifier="departures header top" id="vFr-EO-aUA"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="z2y-8B-H2y"/>
                     </view>
                     <connections>
-                        <outlet property="activityIndicator" destination="2sB-gh-yRe" id="6dV-dl-wR3"/>
+                        <outlet property="activityIndicator" destination="2sB-gh-yRe" id="kGi-Or-3Er"/>
                         <outlet property="departuresHeader" destination="tvM-vn-PsU" id="CNd-kc-6zn"/>
                         <outlet property="tableView" destination="ea4-dX-pgd" id="d2t-oj-YXQ"/>
                     </connections>

--- a/wsdot/Favorites.storyboard
+++ b/wsdot/Favorites.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0hy-HL-p0M">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0hy-HL-p0M">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -150,16 +150,6 @@
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="swG-Qd-xjx">
-                                                    <rect key="frame" x="236" y="61" width="106" height="30"/>
-                                                    <color key="backgroundColor" red="0.93581814240000005" green="0.41981336809999997" blue="0.088704427079999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="27" id="3AN-wb-EZK"/>
-                                                    </constraints>
-                                                    <state key="normal" title="Button">
-                                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    </state>
-                                                </button>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="lKR-ce-07i" firstAttribute="trailing" secondItem="0Qp-7c-ZQx" secondAttribute="trailingMargin" id="2NT-Zx-Bt9"/>
@@ -170,16 +160,12 @@
                                                 <constraint firstItem="v8j-O9-DLU" firstAttribute="centerY" secondItem="0Qp-7c-ZQx" secondAttribute="centerY" id="WuL-kf-mrV"/>
                                                 <constraint firstItem="lKR-ce-07i" firstAttribute="trailing" secondItem="v8j-O9-DLU" secondAttribute="trailing" id="YVI-ca-prQ"/>
                                                 <constraint firstAttribute="bottomMargin" secondItem="z0c-hp-BKz" secondAttribute="bottom" constant="11" id="YkR-G6-bL2"/>
-                                                <constraint firstItem="swG-Qd-xjx" firstAttribute="top" secondItem="v8j-O9-DLU" secondAttribute="bottom" constant="4" id="aGB-cJ-LIC"/>
-                                                <constraint firstItem="swG-Qd-xjx" firstAttribute="leading" secondItem="z0c-hp-BKz" secondAttribute="trailing" constant="8" id="eRi-R1-tpW"/>
                                                 <constraint firstItem="lKR-ce-07i" firstAttribute="leading" secondItem="0Qp-7c-ZQx" secondAttribute="leadingMargin" constant="8" id="hIb-p9-O5d"/>
-                                                <constraint firstAttribute="trailing" secondItem="swG-Qd-xjx" secondAttribute="trailing" id="pRh-NN-fdo"/>
                                                 <constraint firstItem="z0c-hp-BKz" firstAttribute="top" secondItem="v8j-O9-DLU" secondAttribute="bottom" constant="8" id="rVo-wt-Dzs"/>
                                                 <constraint firstItem="z0c-hp-BKz" firstAttribute="width" secondItem="0Qp-7c-ZQx" secondAttribute="width" multiplier="0.6" id="wlo-OE-sQF"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <outlet property="button" destination="swG-Qd-xjx" id="uBp-X7-4f5"/>
                                             <outlet property="subTitleOne" destination="v8j-O9-DLU" id="WrX-bT-1gq"/>
                                             <outlet property="subTitleTwo" destination="z0c-hp-BKz" id="wxq-EE-5XN"/>
                                             <outlet property="title" destination="lKR-ce-07i" id="De5-e7-pKL"/>
@@ -254,7 +240,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ytM-aX-YDP">
-                                                    <rect key="frame" x="317" y="15.5" width="24" height="24"/>
+                                                    <rect key="frame" x="317" y="3.5" width="24" height="48"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="24" id="lJU-Ac-c0g"/>
                                                     </constraints>
@@ -265,7 +251,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="faX-sK-Lym">
-                                                    <rect key="frame" x="255" y="15.5" width="24" height="24"/>
+                                                    <rect key="frame" x="255" y="3.5" width="24" height="48"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="24" id="lPR-Q1-jO8"/>
                                                     </constraints>
@@ -525,10 +511,10 @@ Tap star icons to add Favorites</string>
         </scene>
     </scenes>
     <resources>
-        <image name="icAlert" width="24" height="24"/>
-        <image name="icFavoriteDefault" width="32" height="32"/>
-        <image name="icGear" width="24" height="24"/>
-        <image name="icMap" width="24" height="24"/>
-        <image name="icStarSmall" width="24" height="24"/>
+        <image name="icAlert" width="48" height="48"/>
+        <image name="icFavoriteDefault" width="64" height="64"/>
+        <image name="icGear" width="48" height="48"/>
+        <image name="icMap" width="48" height="48"/>
+        <image name="icStarSmall" width="48" height="48"/>
     </resources>
 </document>

--- a/wsdot/FavoritesHomeViewController.swift
+++ b/wsdot/FavoritesHomeViewController.swift
@@ -524,19 +524,7 @@ extension FavoritesHomeViewController:  UITableViewDataSource, UITableViewDelega
             }
             
             ferryCell.subTitleTwo.text = TimeUtils.timeAgoSinceDate(date: ferryScheduleItem.cacheDate, numericDates: true)
-            
-            let alertCount = ferrySchedules[indexPath.row].routeAlerts.count
-            
-            if (alertCount > 0){
-                ferryCell.button.isHidden = false
-                ferryCell.button.layer.cornerRadius = 5
-                ferryCell.button.tag = indexPath.row
-                ferryCell.button.addTarget(self, action: #selector(FavoritesHomeViewController.openFerryAlerts), for: .touchUpInside)
-                let s = alertCount == 1 ? "" : "s"
-                ferryCell.button.setTitle("\(ferrySchedules[indexPath.row].routeAlerts.count) alert\(s)", for: .normal)
-            } else {
-                ferryCell.button.isHidden = true
-            }
+
             
             return ferryCell
             

--- a/wsdot/Helpers.swift
+++ b/wsdot/Helpers.swift
@@ -180,7 +180,7 @@ struct UIHelpers {
         return label
     }
     
-    static func getBadgeLabel(text: String) -> UILabel {
+    static func getBadgeLabel(text: String, color: UIColor) -> UILabel {
         let label = UILabel(frame: CGRect(x: 10, y: -10, width: 20, height: 20))
         label.layer.borderColor = UIColor.clear.cgColor
         label.layer.borderWidth = 2
@@ -189,7 +189,7 @@ struct UIHelpers {
         label.layer.masksToBounds = true
         label.font = UIFont(name: "SanFranciscoText-Light", size: 13)
         label.textColor = .white
-        label.backgroundColor = .red
+        label.backgroundColor = color
         label.text = text
         return label
     }

--- a/wsdot/Info.plist
+++ b/wsdot/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.11.2</string>
+	<string>5.11.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>5.11.2.0</string>
+	<string>5.11.3.2</string>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/wsdot/RouteAlertsViewController.swift
+++ b/wsdot/RouteAlertsViewController.swift
@@ -32,10 +32,15 @@ class RouteAlertsViewController: UIViewController, UITableViewDataSource, UITabl
     var routeId = 0
     var alertItems = [FerryAlertItem]()
     
+    @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
+    
     let refreshControl = UIRefreshControl()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        activityIndicator.startAnimating()
+        
         tableView.rowHeight = UITableView.automaticDimension
         
         // refresh controller
@@ -74,6 +79,8 @@ class RouteAlertsViewController: UIViewController, UITableViewDataSource, UITabl
                                 selfValue.title = "No Alerts"
                             }
                             
+                            selfValue.activityIndicator.stopAnimating()
+                            selfValue.activityIndicator.isHidden = true
                             selfValue.refreshControl.endRefreshing()
                             UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged, argument: selfValue.tableView)
                         }
@@ -117,6 +124,7 @@ class RouteAlertsViewController: UIViewController, UITableViewDataSource, UITabl
             documentAttributes: nil)
         
         let alertPubDate = TimeUtils.parseJSONDateToNSDate(alertItems[indexPath.row].publishDate)
+        
         cell.updateTime.text = TimeUtils.timeAgoSinceDate(date: alertPubDate, numericDates: false)
         
         cell.linkLabel.attributedText = attrStr

--- a/wsdot/RouteCamerasViewController.swift
+++ b/wsdot/RouteCamerasViewController.swift
@@ -122,22 +122,28 @@ class RouteCamerasViewController: UIViewController, UITableViewDataSource, UITab
     }
     
     // MARK: -
-    // MARK: Helper functinos
+    // MARK: Helper functions
     func filterCameras(_ cameras: [CameraItem]) -> [CameraItem] {
     
         var filteredCameras = [CameraItem]()
-        for camera in cameras {
+        
+        if departingTerminalId != -1 {
+        
+            for camera in cameras {
             
-            let distance = LatLonUtils.haversine(
-                (FerriesConsts().terminalMap[departingTerminalId]?.latitude)!,
-                lonA: (FerriesConsts().terminalMap[departingTerminalId]?.longitude)!,
-                latB: camera.latitude,
-                lonB: camera.longitude)
+                let distance = LatLonUtils.haversine(
+                    (FerriesConsts().terminalMap[departingTerminalId]?.latitude)!,
+                    lonA: (FerriesConsts().terminalMap[departingTerminalId]?.longitude)!,
+                    latB: camera.latitude,
+                    lonB: camera.longitude)
             
-            if (distance < 5280){
-                filteredCameras.append(camera)
+                if (distance < 5280){
+                    filteredCameras.append(camera)
+                }
             }
+        
         }
+        
         return filteredCameras
     }
 }

--- a/wsdot/RouteSchedulesViewController.swift
+++ b/wsdot/RouteSchedulesViewController.swift
@@ -28,7 +28,6 @@ class RouteSchedulesViewController: UIViewController, UITableViewDelegate, UITab
     let cellIdentifier = "FerriesRouteSchedulesCell"
     
     let SegueRouteDeparturesViewController = "RouteDeparturesViewController"
-    let SegueRouteAlertsViewController = "RouteAlertsViewController"
     
     var routes = [FerryScheduleItem]()
     
@@ -143,14 +142,7 @@ class RouteSchedulesViewController: UIViewController, UITableViewDelegate, UITab
         }
         self.present(svc, animated: true, completion: nil)
     }
-    
-    /**
-     * Method name: openAlerts
-     * Description: called when user taps an alert button on a route cell.
-     */
-    @objc func openAlerts(sender: UIButton){
-        performSegue(withIdentifier: SegueRouteAlertsViewController, sender: sender)
-    }
+
     
     // MARK: Table View Data Source Methods
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -173,20 +165,6 @@ class RouteSchedulesViewController: UIViewController, UITableViewDelegate, UITab
         } else {
             cell.subTitleOne.isHidden = true
         }
-        
-        let alertCount = routes[indexPath.row].routeAlerts.count
-        
-        if (alertCount > 0){
-            cell.button.isHidden = false
-            cell.button.layer.cornerRadius = 5
-            cell.button.tag = indexPath.row
-            cell.button.addTarget(self, action: #selector(RouteSchedulesViewController.openAlerts), for: .touchUpInside)
-            let s = alertCount == 1 ? "" : "s"
-            cell.button.setTitle("\(routes[indexPath.row].routeAlerts.count) alert\(s)", for: .normal)
-        } else {
-            cell.button.isHidden = true
-        }
-
 
         cell.subTitleTwo.text = TimeUtils.timeAgoSinceDate(date: self.routes[indexPath.row].cacheDate, numericDates: false)
      
@@ -212,10 +190,6 @@ class RouteSchedulesViewController: UIViewController, UITableViewDelegate, UITab
             }
         }
         
-        if segue.identifier == SegueRouteAlertsViewController {
-            let routeItem = self.routes[(sender as! UIButton).tag] as FerryScheduleItem
-            let destinationViewController: RouteAlertsViewController = segue.destination as! RouteAlertsViewController
-            destinationViewController.routeId = routeItem.routeId
-        }
+
     }
 }

--- a/wsdot/RouteTimesViewController.swift
+++ b/wsdot/RouteTimesViewController.swift
@@ -168,7 +168,6 @@ class RouteTimesViewController: UIViewController, UITableViewDataSource, UITable
         } else {
             self.refreshControl.endRefreshing()
             self.refreshControl.isHidden = true
-            self.activityIndicator.stopAnimating()
         }
     }
     

--- a/wsdot/RoutesCustomCell.swift
+++ b/wsdot/RoutesCustomCell.swift
@@ -25,6 +25,5 @@ class RoutesCustomCell: UITableViewCell {
     @IBOutlet weak var title: UILabel!
     @IBOutlet weak var subTitleOne: UILabel!
     @IBOutlet weak var subTitleTwo: UILabel!
-    @IBOutlet weak var button: UIButton!
     
 }


### PR DESCRIPTION
#139 

Having the button on the routes table cell caused some confusing and made it difficult to tap. The alerts have been moved to the App bar on the sailings screen. A badge will show on the toolbar alert button showing the number of active alerts.  