### PR TITLE
Fixes incorrect day label when using old schedule

### DIFF
--- a/wsdot/RouteDeparturesViewController.swift
+++ b/wsdot/RouteDeparturesViewController.swift
@@ -126,7 +126,12 @@ class RouteDeparturesViewController: UIViewController, GADBannerViewDelegate {
                     self.routeTimesVC.sailingsByDate = routeItemValue.scheduleDates
                     self.routeTimesVC.setDisplayedSailing(0)
                     self.routeTimesVC.refresh(scrollToCurrentSailing: true)
-
+  
+                    if let firstSailingDateValue = routeItemValue.scheduleDates.first {
+                        self.routeTimesVC.dateData = TimeUtils.nextNDayDates(n: routeItemValue.scheduleDates.count, firstSailingDateValue.date)
+                        self.dayButton.setTitle(TimeUtils.getDayOfWeekString(self.routeTimesVC.dateData[self.routeTimesVC.currentDay]), for: UIControl.State())
+                    }
+                    
                     // set terminal for CamerasVC
                     self.routeCamerasVC.departingTerminalId = self.getDepartingId()
                     self.routeCamerasVC.refresh(true)
@@ -216,8 +221,6 @@ class RouteDeparturesViewController: UIViewController, GADBannerViewDelegate {
         if segue.identifier == timesViewSegue {
             routeTimesVC = segue.destination as? RouteTimesViewController
             routeTimesVC.routeId = self.routeId
-            // get the day title from container vc after set up
-            dayButton.setTitle(TimeUtils.getDayOfWeekString(routeTimesVC.dateData[routeTimesVC.currentDay]), for: UIControl.State())
         }
         
         if segue.identifier == SegueRouteAlertsViewController {

--- a/wsdot/RouteTimesViewController.swift
+++ b/wsdot/RouteTimesViewController.swift
@@ -60,26 +60,7 @@ class RouteTimesViewController: UIViewController, UITableViewDataSource, UITable
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setDisplayedSailing(0)
-        
-        let routeItem = FerryRealmStore.findSchedule(withId: self.routeId)
-        
-        if let routeItemValue = routeItem {
-
-            // Set sailings for RouteTimesVC
-            self.currentSailing = routeItemValue.terminalPairs[0]
-            self.sailingsByDate = routeItemValue.scheduleDates
-            self.setDisplayedSailing(0)
-            self.refresh(scrollToCurrentSailing: true)
-            
-            if let sailingsByDateValue = sailingsByDate {
-        
-                if let firstSailingDateValue = sailingsByDateValue.first {
-            
-                    dateData = TimeUtils.nextNDayDates(n: sailingsByDateValue.count, firstSailingDateValue.date)
-                }
-            }
-        }
+        setDisplayedSailing(0)   
         
         self.tableView.isHidden = true
         


### PR DESCRIPTION
Issue #141 

Sets the day label after we’ve retrieved a ferry schedule. No longer
assumes the schedule starts on the current day.