### PR TITLE
Revert "Set URLSession to default Alamofire session"

### DIFF
--- a/wsdot/EventStore.swift
+++ b/wsdot/EventStore.swift
@@ -67,8 +67,12 @@ class EventStore {
 
 
     static func fetchAndSaveEventItem(validJSONCheck: Bool, completion: @escaping EventCompletion) {
+        
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        eventSession = Session(configuration: configuration)
 
-        AF.request("https://data.wsdot.wa.gov/mobile/EventStatus.js").validate().responseJSON { response in
+        eventSession!.request("https://data.wsdot.wa.gov/mobile/EventStatus.js").validate().responseJSON { response in
             switch response.result {
             case .success:
                 if let value = response.data {


### PR DESCRIPTION
Fixes issue with event banner data not updating correctly after app has been inactive.

This reverts commit c7c9031bf585ca2831cd06e5da8f523cf3737dfd.

---------------
Development Environment
- Macbook Pro: Apple M1 Pro
- macOS Monterey Version 12.6
- Xcode 14.0.1